### PR TITLE
Allow ngrok exec to fail gracefully

### DIFF
--- a/src/ngrok.ts
+++ b/src/ngrok.ts
@@ -31,7 +31,11 @@ export function ngrok_installed(): Promise<boolean> {
   return new Promise((resolve, reject) => {
     exec(`ngrok --version`, (error, std_out) => {
       if (error) {
-        reject(error)
+        if (error.code === 1) {
+          resolve(false) // ngrok command not installed
+        } else {
+          reject(error)
+        }
       } else {
         resolve(std_out.substring(0, 5) == 'ngrok')
       }

--- a/src/ngrok.ts
+++ b/src/ngrok.ts
@@ -31,7 +31,7 @@ export function ngrok_installed(): Promise<boolean> {
   return new Promise((resolve, reject) => {
     exec(`ngrok --version`, (error, std_out) => {
       if (error) {
-        if (error.code === 1) {
+        if (error.code === 127) {
           resolve(false) // ngrok command not installed
         } else {
           reject(error)


### PR DESCRIPTION
Current behavior with ngrok NOT installed:

![Screen Shot 2021-05-10 at 10 29 28 AM](https://user-images.githubusercontent.com/8585377/117684562-bd00ba00-b17a-11eb-8eb2-69fe1c6f555c.png)

Changes should allow for the [ngrok check](https://github.com/christyharagan/segment-sloth/blob/c6b1c0c394f7994cbe089f210dc085f412b8142b/src/cli/init.ts#L74) to work even when ngrok is not installed.

For me, this is necessary because some companies block services like ngrok.
